### PR TITLE
Add basic group management frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,20 +1,46 @@
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
 import LoginPage from './LoginPage.jsx'
 import SignupPage from './SignupPage.jsx'
+import GroupsPage from './GroupsPage.jsx'
+import CreateGroupPage from './CreateGroupPage.jsx'
+import InvitationsPage from './InvitationsPage.jsx'
+import { AuthProvider, useAuth } from './AuthContext.jsx'
+
+function Navigation() {
+  const { token, setToken } = useAuth()
+  return (
+    <nav className="mb-4 flex gap-4 text-blue-600">
+      {token ? (
+        <>
+          <Link to="/groups">Groups</Link>
+          <Link to="/invitations">Invitations</Link>
+          <button onClick={() => setToken('')} className="text-red-600">Sign Out</button>
+        </>
+      ) : (
+        <>
+          <Link to="/">Login</Link>
+          <Link to="/signup">Sign Up</Link>
+        </>
+      )}
+    </nav>
+  )
+}
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <div className="mx-auto max-w-md p-4">
-        <nav className="mb-4 flex gap-4 text-blue-600">
-          <Link to="/">Login</Link>
-          <Link to="/signup">Sign Up</Link>
-        </nav>
-        <Routes>
-          <Route path="/" element={<LoginPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-        </Routes>
-      </div>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <div className="mx-auto max-w-md p-4">
+          <Navigation />
+          <Routes>
+            <Route path="/" element={<LoginPage />} />
+            <Route path="/signup" element={<SignupPage />} />
+            <Route path="/groups" element={<GroupsPage />} />
+            <Route path="/groups/new" element={<CreateGroupPage />} />
+            <Route path="/invitations" element={<InvitationsPage />} />
+          </Routes>
+        </div>
+      </BrowserRouter>
+    </AuthProvider>
   )
 }

--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -1,0 +1,23 @@
+import { createContext, useState, useContext, useEffect } from 'react'
+
+const AuthContext = createContext()
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem('token') || '')
+
+  useEffect(() => {
+    if (token) localStorage.setItem('token', token)
+    else localStorage.removeItem('token')
+  }, [token])
+
+  return (
+    <AuthContext.Provider value={{ token, setToken }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAuth() {
+  return useContext(AuthContext)
+}

--- a/frontend/src/CreateGroupPage.jsx
+++ b/frontend/src/CreateGroupPage.jsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from './AuthContext.jsx'
+import { Button, Input, Label } from './components/ui'
+
+const API_URL = 'http://localhost:5000'
+
+export default function CreateGroupPage() {
+  const { token } = useAuth()
+  const navigate = useNavigate()
+  const [name, setName] = useState('')
+  const [invitees, setInvitees] = useState('')
+  const [message, setMessage] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setMessage('')
+    try {
+      const res = await fetch(`${API_URL}/groups`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          name,
+          invitees: invitees.split(',').map((s) => s.trim()).filter(Boolean)
+        })
+      })
+      const data = await res.json()
+      if (res.ok) {
+        navigate('/groups')
+      } else {
+        setMessage(data.error || 'Error creating group')
+      }
+    } catch {
+      setMessage('Network error')
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Create Group</h2>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <div className="space-y-1">
+          <Label htmlFor="name">Group Name</Label>
+          <Input id="name" value={name} onChange={(e) => setName(e.target.value)} required />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="invitees">Invite Users (comma separated)</Label>
+          <Input id="invitees" value={invitees} onChange={(e) => setInvitees(e.target.value)} />
+        </div>
+        <Button type="submit">Create</Button>
+      </form>
+      {message && <p className="text-sm text-red-500">{message}</p>}
+    </div>
+  )
+}

--- a/frontend/src/GroupsPage.jsx
+++ b/frontend/src/GroupsPage.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth } from './AuthContext.jsx'
+import { Button } from './components/ui'
+
+const API_URL = 'http://localhost:5000'
+
+export default function GroupsPage() {
+  const { token } = useAuth()
+  const [groups, setGroups] = useState([])
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    async function fetchGroups() {
+      try {
+        const res = await fetch(`${API_URL}/groups`, {
+          headers: { Authorization: `Bearer ${token}` }
+        })
+        if (res.ok) {
+          const data = await res.json()
+          setGroups(data)
+        } else {
+          setMessage('Error loading groups')
+        }
+      } catch {
+        setMessage('Network error')
+      }
+    }
+    if (token) fetchGroups()
+  }, [token])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between">
+        <h2 className="text-xl font-semibold">Your Groups</h2>
+        <Link to="/groups/new" className="text-blue-600">Create Group</Link>
+      </div>
+      {groups.length === 0 && <p>No groups yet.</p>}
+      <ul className="space-y-2">
+        {groups.map((g) => (
+          <li key={g.id} className="rounded border p-2">{g.name}</li>
+        ))}
+      </ul>
+      {message && <p className="text-sm text-red-500">{message}</p>}
+    </div>
+  )
+}

--- a/frontend/src/InvitationsPage.jsx
+++ b/frontend/src/InvitationsPage.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import { useAuth } from './AuthContext.jsx'
+import { Button } from './components/ui'
+
+const API_URL = 'http://localhost:5000'
+
+export default function InvitationsPage() {
+  const { token } = useAuth()
+  const [invitations, setInvitations] = useState([])
+  const [message, setMessage] = useState('')
+
+  async function load() {
+    try {
+      const res = await fetch(`${API_URL}/invitations`, {
+        headers: { Authorization: `Bearer ${token}` }
+      })
+      if (res.ok) {
+        setInvitations(await res.json())
+      } else {
+        setMessage('Error loading invitations')
+      }
+    } catch {
+      setMessage('Network error')
+    }
+  }
+
+  useEffect(() => {
+    if (token) load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token])
+
+  async function respond(id, action) {
+    try {
+      const res = await fetch(`${API_URL}/invitations/${id}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ action })
+      })
+      if (res.ok) {
+        setInvitations((prev) => prev.filter((i) => i.id !== id))
+      }
+    } catch {
+      setMessage('Network error')
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Invitations</h2>
+      {invitations.length === 0 && <p>No pending invitations.</p>}
+      <ul className="space-y-2">
+        {invitations.map((inv) => (
+          <li key={inv.id} className="rounded border p-2">
+            <p>
+              {inv.inviter} invited you to {inv.group_name}
+            </p>
+            <div className="mt-2 space-x-2">
+              <Button onClick={() => respond(inv.id, 'accept')}>Accept</Button>
+              <Button onClick={() => respond(inv.id, 'reject')} className="bg-red-500 hover:bg-red-600">
+                Reject
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {message && <p className="text-sm text-red-500">{message}</p>}
+    </div>
+  )
+}

--- a/frontend/src/LoginPage.jsx
+++ b/frontend/src/LoginPage.jsx
@@ -1,9 +1,13 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Button, Input, Label } from './components/ui'
+import { useAuth } from './AuthContext.jsx'
 
 const API_URL = 'http://localhost:5000'
 
 export default function LoginPage() {
+  const { setToken } = useAuth()
+  const navigate = useNavigate()
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [message, setMessage] = useState('')
@@ -19,7 +23,8 @@ export default function LoginPage() {
       })
       const data = await res.json()
       if (res.ok) {
-        setMessage('Logged in! Token: ' + data.access_token)
+        setToken(data.access_token)
+        navigate('/groups')
       } else {
         setMessage(data.error || 'Error logging in')
       }


### PR DESCRIPTION
## Summary
- expose `/groups` and `/invitations` listing endpoints
- create React auth context
- add pages for listing groups, creating groups and viewing invites
- wire up login page and navigation to use auth context

## Testing
- `npm run lint`
- `python -m py_compile backend/routes/group.py`


------
https://chatgpt.com/codex/tasks/task_e_6866653e9aac8323a36ef8769404cdc3